### PR TITLE
Expose stderr when something fails

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -62,7 +62,8 @@ class Pyls(AbstractPlugin):
             startupinfo.dwFlags |= flag
         else:
             startupinfo = None
-        return subprocess.check_output(args=args, cwd=kwargs.get("cwd"), startupinfo=startupinfo)
+        return subprocess.check_output(args=args, cwd=kwargs.get("cwd"), startupinfo=startupinfo,
+                                       stderr=subprocess.STDOUT)
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:


### PR DESCRIPTION
The stderr will be available in the output property of
subprocess.CalledProcessError exception.

The relevant change in LSP will be done as a separate PR.