### PR TITLE
refactor: remove redundant $sublime_packages_dir variable

### DIFF
--- a/LSP-pyls.sublime-settings
+++ b/LSP-pyls.sublime-settings
@@ -34,19 +34,19 @@
     "pyls_black_version": "0.4.6",
     "pyls_isort_version": "0.1.1",
     "env": {
-        "PYTHONPATH": "$sublime_py_files_dir:$sublime_packages_dir",
-        "MYPY_PATH": "$sublime_py_files_dir:$sublime_packages_dir"
+        "PYTHONPATH": "$sublime_py_files_dir:$packages",
+        "MYPY_PATH": "$sublime_py_files_dir:$packages"
     },
     "settings": {
         // --- env ------------------------------------------------------------
         "pyls.env": {
-            "PYTHONPATH": "$sublime_py_files_dir:$sublime_packages_dir",
-            "MYPY_PATH": "$sublime_py_files_dir:$sublime_packages_dir"
+            "PYTHONPATH": "$sublime_py_files_dir:$packages",
+            "MYPY_PATH": "$sublime_py_files_dir:$packages"
         },
         // --- JEDI configuration ---------------------------------------------
         "pyls.plugins.jedi.extra_paths": [
             "$sublime_py_files_dir",
-            "$sublime_packages_dir"
+            "$packages"
         ],
         "pyls.plugins.jedi.jedi_completion.fuzzy": true,
         "pyls.plugins.jedi.pycodestyle.enabled": false,

--- a/plugin.py
+++ b/plugin.py
@@ -16,7 +16,6 @@ class Pyls(AbstractPlugin):
     def additional_variables(cls) -> Optional[Dict[str, str]]:
         variables = {}
         variables['sublime_py_files_dir'] = os.path.dirname(sublime.__file__)
-        variables["sublime_packages_dir"] = sublime.packages_path()
         return variables
 
     @classmethod


### PR DESCRIPTION
Doing the same thing with https://github.com/sublimelsp/LSP-pyright/pull/8.

It's the same with ST's built-in `$packages` from `window.extract_variables()`.
This is a BC break but I assume this package is not published on PC so only very few people will be affected?