### PR TITLE
plugin: Use correct path in windows env

### DIFF
--- a/LSP-pyls.sublime-settings
+++ b/LSP-pyls.sublime-settings
@@ -23,7 +23,7 @@
 // $DATA/Packages/User/LSP-pyls.sublime-settings.
 {
     "command": [
-        "$cache_path/../Package Storage/LSP-pyls/bin/pyls"
+        "$pyls_path"
     ],
     "languages": [
         {

--- a/plugin.py
+++ b/plugin.py
@@ -26,7 +26,8 @@ class Pyls(AbstractPlugin):
 
     @classmethod
     def bindir(cls) -> str:
-        return os.path.join(cls.basedir(), "bin")
+        bin_dir = "Scripts" if sublime.platform() == "windows" else "bin"
+        return os.path.join(cls.basedir(), bin_dir)
 
     @classmethod
     def server_exe(cls) -> str:

--- a/plugin.py
+++ b/plugin.py
@@ -18,6 +18,7 @@ class Pyls(AbstractPlugin):
     def additional_variables(cls) -> Optional[Dict[str, str]]:
         variables = {}
         variables['sublime_py_files_dir'] = os.path.dirname(sublime.__file__)
+        variables['pyls_path'] = cls.server_exe()
         return variables
 
     @classmethod


### PR DESCRIPTION
Crashed for me, and I noticed that in windows env, the `pip` and `pyls` bins are located in a folder named `Scripts`